### PR TITLE
support vrf in different tenant

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -286,7 +286,7 @@ PLUGINS_CONFIG = {
         # Manufacturer name. Specify existing, or a new one with this name will be created.
         "manufacturer_name": "Cisco",
         # Exclude any tenants you would not like to bring over from ACI.
-        "ignore_tenants": ["common", "mgmt", "infra"],
+        "ignore_tenants": ["mgmt", "infra"],
         # The below value will appear in the Comments field on objects created in Nautobot
         "comments": "Created by ACI SSoT Plugin",
         # Site to associate objects. Specify existing, or a new site with this name will be created.

--- a/nautobot_ssot_aci/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot_aci/diffsync/adapters/nautobot.py
@@ -58,6 +58,7 @@ class NautobotAdapter(DiffSync):
         self.sync = sync
         self.site = client.get("site")
         self.site_tag = Tag.objects.get_or_create(name=self.site)[0]
+        self.tenant_prefix = client.get("tenant_prefix")
 
     def load_tenants(self):
         """Method to load Tenants from Nautobot."""
@@ -183,8 +184,14 @@ class NautobotAdapter(DiffSync):
         for nbprefix in Prefix.objects.filter(tags=self.site_tag):
             if nbprefix.vrf:
                 vrf = nbprefix.vrf.name
+                if nbprefix.vrf.tenant.name:
+                    vrf_tenant = f"{self.tenant_prefix}:{nbprefix.vrf.tenant.name}"
+                else:
+                    vrf_tenant = None
             else:
                 vrf = None
+                vrf_tenant = None
+            
             _prefix = self.prefix(
                 prefix=str(nbprefix.prefix),
                 status=nbprefix.status.name,
@@ -192,6 +199,7 @@ class NautobotAdapter(DiffSync):
                 description=nbprefix.description,
                 tenant=nbprefix.tenant.name,
                 vrf=vrf,
+                vrf_tenant=vrf_tenant,
                 site_tag=self.site,
             )
             self.add(_prefix)

--- a/nautobot_ssot_aci/diffsync/client.py
+++ b/nautobot_ssot_aci/diffsync/client.py
@@ -337,12 +337,13 @@ class AciApi:
             resp = self._get(
                 f"/api/node/mo/uni/tn-{bd_dict[bd]['tenant']}/BD-{bd}.json?query-target=children&target-subtree-class=fvRsCtx"
             )
-
-            # bd_dict[bd]["vrf"] = [data["fvRsCtx"]["attributes"]["tnFvCtxName"] for data in resp.json()["imdata"]][0]
             for data in resp.json()["imdata"]:
-                tnt_vrf = data["fvRsCtx"]["attributes"].get("tnFvCtxName", "default")
-                bd_dict[bd]["vrf"] = tnt_vrf
-
+                bd_dict[bd]["vrf"] = data["fvRsCtx"]["attributes"].get("tnFvCtxName", "default")
+                vrf_tenant = data["fvRsCtx"]["attributes"].get("tDn", None)
+                if vrf_tenant:
+                    bd_dict[bd]["vrf_tenant"] = tenant_from_dn(vrf_tenant)
+                else:
+                    bd_dict[bd]["vrf_tenant"] = None
             # get subnets
             resp = self._get(
                 f"/api/node/mo/uni/tn-{bd_dict[bd]['tenant']}/BD-{bd}.json?query-target=children&target-subtree-class=fvSubnet"

--- a/nautobot_ssot_aci/diffsync/models/base.py
+++ b/nautobot_ssot_aci/diffsync/models/base.py
@@ -119,7 +119,7 @@ class IPAddress(DiffSyncModel):
         "address",
         "site",
     )
-    _attributes = ("status", "description", "device", "interface", "vrf", "tenant", "site_tag")
+    _attributes = ("status", "description", "device", "interface", "vrf", "tenant", "vrf_tenant", "site_tag")
 
     address: str
     status: str
@@ -129,6 +129,7 @@ class IPAddress(DiffSyncModel):
     device: Optional[str]
     interface: Optional[str]
     tenant: Optional[str]
+    vrf_tenant: Optional[str]
     site_tag: str
 
 
@@ -140,7 +141,7 @@ class Prefix(DiffSyncModel):
         "prefix",
         "site",
     )
-    _attributes = ("status", "description", "vrf", "tenant", "site_tag")
+    _attributes = ("status", "description", "vrf", "tenant", "vrf_tenant", "site_tag")
 
     prefix: str
     status: str
@@ -148,6 +149,7 @@ class Prefix(DiffSyncModel):
     tenant: Optional[str]
     description: Optional[str]
     vrf: Optional[str]
+    vrf_tenant: Optional[str]
     site_tag: str
 
 

--- a/nautobot_ssot_aci/diffsync/models/nautobot.py
+++ b/nautobot_ssot_aci/diffsync/models/nautobot.py
@@ -456,14 +456,20 @@ class NautobotPrefix(Prefix):
     @classmethod
     def create(cls, diffsync, ids, attrs):
         """Create Prefix object in Nautobot."""
-        _tenant_name = attrs["tenant"]
+        # _tenant_name = attrs["tenant"]
+        # try:
+        #     _tenant = OrmTenant.objects.get(name=attrs["tenant"])
+        # except ObjectNotCreated:
+        #     diffsync.job.log_warning(message=f"Tenant {_tenant_name} not found!")
         try:
-            _tenant = OrmTenant.objects.get(name=attrs["tenant"])
-        except ObjectNotCreated:
-            diffsync.job.log_warning(message=f"Tenant {_tenant_name} not found!")
-        if attrs["vrf"]:
+            vrf_tenant = OrmTenant.objects.get(name=attrs["vrf_tenant"])
+        except OrmTenant.DoesNotExist:
+            diffsync.job.log_warning(message=f"Tenant {attrs['vrf_tenant']} not found for VRF {attrs['vrf']}")
+            vrf_tenant = None
+
+        if attrs["vrf"] and vrf_tenant:
             try:
-                vrf = OrmVrf.objects.get(name=attrs["vrf"], tenant=_tenant)
+                vrf = OrmVrf.objects.get(name=attrs["vrf"], tenant=OrmTenant.objects.get(name=attrs["vrf_tenant"]))
             except OrmVrf.DoesNotExist:
                 diffsync.job.log_warning(message=f"VRF {attrs['vrf']} not found to associate prefix {ids['prefix']}")
                 vrf = None


### PR DESCRIPTION
Enables support for having a Bridge Domain in ACI that uses a VRF from a different tenant.  Also adds error handling for Bridge Domains that are mis-configured with a missing or invalid VRF.  